### PR TITLE
Enable nullable reference types

### DIFF
--- a/src/DotRange.Tests/DotRange.Tests.csproj
+++ b/src/DotRange.Tests/DotRange.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DotRange/Cut.cs
+++ b/src/DotRange/Cut.cs
@@ -55,8 +55,12 @@ internal abstract class Cut<C> : IComparable<Cut<C>> where C : IComparable<C>
     internal abstract void DescribeAsUpperBound(StringBuilder sb);
 
     // note: overridden by {BELOW,ABOVE}_ALL
-    public virtual int CompareTo(Cut<C> that)
+    public virtual int CompareTo(Cut<C>? that)
     {
+        if (that is null)
+        {
+            return 1;
+        }
         if (that == BelowAll.INSTANCE)
         {
             return 1;
@@ -79,7 +83,7 @@ internal abstract class Cut<C> : IComparable<Cut<C>> where C : IComparable<C>
         return _endpoint;
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (obj is Cut<C> that)
         {
@@ -98,7 +102,7 @@ internal abstract class Cut<C> : IComparable<Cut<C>> where C : IComparable<C>
     {
         public static readonly BelowAll INSTANCE = new BelowAll();
 
-        internal BelowAll() : base(default(C))
+        internal BelowAll() : base(default!)
         {
         }
         internal override C Endpoint()
@@ -125,7 +129,7 @@ internal abstract class Cut<C> : IComparable<Cut<C>> where C : IComparable<C>
         {
             throw new InvalidOperationException();
         }
-        public override int CompareTo(Cut<C> o)
+        public override int CompareTo(Cut<C>? o)
         {
             return (o is BelowAll) ? 0 : -1;
         }
@@ -144,7 +148,7 @@ internal abstract class Cut<C> : IComparable<Cut<C>> where C : IComparable<C>
     {
         internal static readonly AboveAll INSTANCE = new AboveAll();
 
-        internal AboveAll() : base(default(C))
+        internal AboveAll() : base(default!)
         {
         }
         internal override C Endpoint()
@@ -171,7 +175,7 @@ internal abstract class Cut<C> : IComparable<Cut<C>> where C : IComparable<C>
         {
             sb.Append("+\u221e)");
         }
-        public override int CompareTo(Cut<C> o)
+        public override int CompareTo(Cut<C>? o)
         {
             return (o is AboveAll) ? 0 : 1;
         }

--- a/src/DotRange/DotRange.csproj
+++ b/src/DotRange/DotRange.csproj
@@ -9,6 +9,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/paolofulgoni/DotRange</RepositoryUrl>
     <Copyright>Copyright Paolo Fulgoni 2018</Copyright>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/src/DotRange/Range.cs
+++ b/src/DotRange/Range.cs
@@ -475,7 +475,7 @@ public sealed class Range<C> where C : IComparable<C>
     /// Similarly, empty ranges are not equal unless they have exactly the same representation, so
     /// <c>[3..3)</c>, <c>(3..3]</c>, <c>(4..4]</c> are all unequal.
     /// </summary>
-    public override bool Equals(object other)
+    public override bool Equals(object? other)
     {
         if (other is Range<C> otherRange)
         {


### PR DESCRIPTION
## Summary
- enable nullable reference types in projects
- update Range.Equals signature
- fix nullability warnings in Cut

## Testing
- `dotnet build --nologo`
- `dotnet test --no-build --nologo`
