### PR TITLE
Add minimal .editorconfig and format code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+charset = utf-8-bom
+end_of_line = lf
+insert_final_newline = true
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = true

--- a/src/SharpInterval.Tests/IntervalTest.cs
+++ b/src/SharpInterval.Tests/IntervalTest.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq;
+
 using FluentAssertions;
+
 using NUnit.Framework;
 
 namespace SharpInterval.Tests;
@@ -250,7 +252,7 @@ public class IntervalTest
 
         Action act1 = () => interval.UpperEndpoint();
         act1.Should().Throw<InvalidOperationException>();
-            
+
         Action act2 = () => interval.UpperBoundType();
         act2.Should().Throw<InvalidOperationException>();
     }
@@ -325,7 +327,7 @@ public class IntervalTest
 
         interval.Intersection(Interval.AtMost(3)).Should().Be(Interval.OpenClosed(3, 3));
         interval.Intersection(Interval.AtLeast(4)).Should().Be(Interval.ClosedOpen(4, 4));
-        
+
         Action act1 = () => interval.Intersection(Interval.LessThan(3));
         act1.Should().Throw<ArgumentException>();
 


### PR DESCRIPTION
## Summary
- add a minimal .NET `.editorconfig`
- run `dotnet format` to apply style settings

## Testing
- `dotnet format SharpInterval.sln --no-restore --verify-no-changes --verbosity diagnostic`
- `dotnet build`
- `dotnet test --no-build --verbosity normal`