### PR TITLE
docs: Simplify mathematical language and improve clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,74 +7,78 @@ Define, combine, and test value intervals in .NET
 
 ## Introduction
 
-An interval, sometimes known as a range, is a convex (informally, "contiguous"
-or "unbroken") portion of a particular domain. Formally, convexity means that
-for any `a <= b <= c`, `interval.Contains(a) && interval.Contains(c)` implies that
-`interval.Contains(b)`.
+An interval represents a continuous range of values. Think of it as a segment on a number line, or a portion of a sequence. For example, all numbers between 1 and 5, or all dates in a specific week.
 
-The word "range" is a common synonym for "interval", but the name `Interval` is used here to avoid clashes with `System.Range`.
+The word "range" is a common synonym for "interval," but this library uses the name `Interval` to avoid confusion with other programming constructs like `System.Range`.
 
-Intervals may "extend to infinity" -- for example, the interval `x > 3` contains
-arbitrarily large values -- or may be finitely constrained, for example `2 <= x
-< 5`. We will use the more compact notation, familiar to programmers with a math
-background:
+Intervals can be finite (e.g., numbers between 2 and 5) or they can extend indefinitely in one or both directions (e.g., all numbers greater than 3).
 
-*   `(a..b) = {x | a < x < b}`
-*   `[a..b] = {x | a <= x <= b}`
-*   `[a..b) = {x | a <= x < b}`
-*   `(a..b] = {x | a < x <= b}`
-*   `(a..+∞) = {x | x > a}`
-*   `[a..+∞) = {x | x >= a}`
-*   `(-∞..b) = {x | x < b}`
-*   `(-∞..b] = {x | x <= b}`
-*   `(-∞..+∞) = all values`
+To describe intervals concisely, we use a common mathematical notation:
 
-The values a and b used above are called endpoints. To improve consistency,
-SharpInterval's notion of `Interval` requires that the upper endpoint may not be less than
-the lower endpoint. The endpoints may be equal only if at least one of the
-bounds is closed:
+*   An interval like **`(a..b)`** represents all values **greater than 'a' and less than 'b'**. 'a' and 'b' themselves are *not* included. This is called an **open interval**. For example, `(1..5)` includes numbers like 1.1, 2, 4.9, but not 1 or 5.
+*   An interval like **`[a..b]`** represents all values **greater than or equal to 'a' and less than or equal to 'b'**. 'a' and 'b' *are* included. This is called a **closed interval**. For example, `[1..5]` includes 1, 5, and all numbers in between.
+*   An interval like **`[a..b)`** represents all values **greater than or equal to 'a' and less than 'b'**. 'a' *is* included, but 'b' is *not*. This is a **half-open interval** (closed at the start, open at the end). For example, `[1..5)` includes 1, 4.999..., but not 5.
+*   An interval like **`(a..b]`** represents all values **greater than 'a' and less than or equal to 'b'**. 'a' is *not* included, but 'b' *is*. This is also a **half-open interval** (open at the start, closed at the end). For example, `(1..5]` includes 1.000...1, 5, but not 1.
 
-*   `[a..a]`: singleton interval
-*   `[a..a); (a..a]`: empty, but valid
-*   `(a..a)`: invalid
+Intervals can also be unbounded on one side, using `+∞` (positive infinity) or `-∞` (negative infinity):
+
+*   **`(a..+∞)`**: All values **strictly greater than 'a'**. For example, `(5..+∞)` means all numbers from 5.000...1 upwards.
+*   **`[a..+∞)`**: All values **greater than or equal to 'a'**. For example, `[5..+∞)` means all numbers from 5 upwards.
+*   **`(-∞..b)`**: All values **strictly less than 'b'**. For example, `(-∞..5)` means all numbers up to 4.999....
+*   **`(-∞..b]`**: All values **less than or equal to 'b'**. For example, `(-∞..5]` means all numbers up to 5.
+*   **`(-∞..+∞)`**: Represents **all possible values** in the domain.
+
+The values 'a' and 'b' in these notations are called the **endpoints** of the interval. They define the boundaries of the range.
+Whether an endpoint is included or excluded determines if the interval's bound is **closed** (inclusive) or **open** (exclusive).
+For example, `[10..20]` means both 10 and 20 are included (closed bounds). In `(10..20)`, neither 10 nor 20 are included (open bounds).
+
+In SharpInterval, the upper endpoint must generally be greater than or equal to the lower endpoint.
+What happens if the endpoints are equal?
+*   `[a..a]`: This creates an interval containing a single value 'a' (e.g., `[5..5]` contains only 5). This is a **singleton interval**.
+*   `[a..a)` or `(a..a]`: These define an **empty interval**, but are still considered valid. For example, `[5..5)` means "numbers greater than or equal to 5, but less than 5," which is impossible, hence empty. Similarly for `(5..5]`.
+*   `(a..a)`: This is **invalid** because it means "numbers strictly greater than 'a' and strictly less than 'a'," which cannot be represented logically as an interval in this library.
 
 An interval in SharpInterval has the type `Interval<T>`. All intervals are *immutable*.
 
 ## Building Intervals
 
-Intervals can be obtained from the static methods on `Interval`:
+You can create intervals using static methods on the `Interval` class.
 
-Interval type | Method
-:--------- | :-------------------
-`(a..b)`   | `Open(T, T)`
-`[a..b]`   | `Closed(T, T)`
-`[a..b)`   | `ClosedOpen(T, T)`
-`(a..b]`   | `OpenClosed(T, T)`
-`(a..+∞)`  | `GreaterThan(T)`
-`[a..+∞)`  | `AtLeast(T)`
-`(-∞..b)`  | `LessThan(T)`
-`(-∞..b]`  | `AtMost(T)`
-`(-∞..+∞)` | `All()`
+Here's how the notation maps to the factory methods:
+
+Interval type | Method                | Plain English Explanation
+:-------------| :-------------------- | :--------------------------------------------------------------------------
+`(a..b)`      | `Open(T, T)`          | Values strictly between 'a' and 'b' (a and b are not included).
+`[a..b]`      | `Closed(T, T)`        | Values between 'a' and 'b', including 'a' and 'b'.
+`[a..b)`      | `ClosedOpen(T, T)`    | Values from 'a' (included) up to 'b' (not included).
+`(a..b]`      | `OpenClosed(T, T)`    | Values from 'a' (not included) up to 'b' (included).
+`(a..+∞)`     | `GreaterThan(T)`      | Values strictly greater than 'a'.
+`[a..+∞)`     | `AtLeast(T)`          | Values greater than or equal to 'a'.
+`(-∞..b)`     | `LessThan(T)`         | Values strictly less than 'b'.
+`(-∞..b]`     | `AtMost(T)`           | Values less than or equal to 'b'.
+`(-∞..+∞)`    | `All()`               | All possible values.
 
 ```cs
-Interval.Closed("left", "right"); // all strings lexicographically between "left" and "right" inclusive
-Interval.LessThan(4.0); // double values strictly less than 4
+Interval.Closed("left", "right"); // All strings alphabetically (or in dictionary order) between "left" and "right", inclusive.
+Interval.LessThan(4.0); // Double values strictly less than 4.0.
 ```
 
-Additionally, Interval instances can be constructed by passing the bound types
-explicitly:
+You can also construct intervals by specifying the `BoundType` (which can be `Closed` or `Open`) for each endpoint:
 
-Interval type                                   | Method
-:------------------------------------------- | :-----
-Bounded on both ends                         | `Bounded(T, BoundType, T, BoundType)`
-Unbounded on top (`(a..+∞)` or `[a..+∞)`)    | `DownTo(T, BoundType)`
-Unbounded on bottom (`(-∞..b)` or `(-∞..b]`) | `UpTo(T, BoundType)`
+Interval type Creation                                            | Method                                       | Plain English Explanation
+:-----------------------------------------------------------------| :------------------------------------------- | :-----------------------------------------------------------------------------------------------------
+Bounded on both ends                                              | `Bounded(T, BoundType, T, BoundType)`        | Values between two points, where you can specify if each point is included or excluded.
+Unbounded on top (e.g., `(a..+∞)` or `[a..+∞)`)                   | `DownTo(T, BoundType)`                       | Values from a starting point (which can be included or excluded based on `BoundType`) extending indefinitely upwards.
+Unbounded on bottom (e.g., `(-∞..b)` or `(-∞..b]`)                | `UpTo(T, BoundType)`                         | Values up to an ending point (which can be included or excluded based on `BoundType`) extending indefinitely downwards.
 
-Here, `BoundType` is an enum containing the values `Closed` and `Open`.
+Here, `BoundType` is an enum with two values: `BoundType.Closed` (the endpoint is included) and `BoundType.Open` (the endpoint is excluded).
 
 ```cs
-Interval.DownTo(4, boundType); // allows you to decide whether or not you want to include 4
-Interval.Bounded(1, BoundType.Closed, 4, BoundType.Open); // another way of writing Interval.ClosedOpen(1, 4)
+// Creates an interval like [4..+∞) if boundType is Closed, or (4..+∞) if boundType is Open
+Interval.DownTo(4, boundType); 
+
+// This is another way to write Interval.ClosedOpen(1, 4), which is [1..4)
+Interval.Bounded(1, BoundType.Closed, 4, BoundType.Open); 
 ```
 
 ## Operations
@@ -92,19 +96,15 @@ Interval.Closed(1, 4).ContainsAll(new int[] { 1, 2, 3 }); // returns true
 
 ### Query Operations
 
-To look at the endpoints of an interval, `Interval` exposes the following methods:
+These methods let you inspect the properties of an interval:
 
-*   `HasLowerBound()` and `HasUpperBound()`, which check if the interval has
-    the specified endpoints, or goes on "through infinity."
-*   `LowerBoundType()` and `UpperBoundType()` return the `BoundType` for the
-    corresponding endpoint, which can be either `Closed` or `Open`. If this
-    interval does not have the specified endpoint, the method throws an
-    `InvalidOperationException`.
-*   `LowerEndpoint()` and `UpperEndpoint()` return the endpoints on the
-    specified end, or throw an `InvalidOperationException` if the interval does not
-    have the specified endpoint.
-*   `IsEmpty()` tests if the interval is empty, that is, it has the form `[a,a)`
-    or `(a,a]`.
+*   `HasLowerBound()`: Checks if the interval has a defined starting point (i.e., it's not `(-∞..something)`).
+*   `HasUpperBound()`: Checks if the interval has a defined ending point (i.e., it's not `(something..+∞)`).
+*   `LowerBoundType()`: Returns the type of the lower bound (`Open` or `Closed`). Throws an exception if there's no lower bound (it extends to `-∞`).
+*   `UpperBoundType()`: Returns the type of the upper bound (`Open` or `Closed`). Throws an exception if there's no upper bound (it extends to `+∞`).
+*   `LowerEndpoint()`: Gets the starting value of the interval. Throws an exception if there's no lower bound.
+*   `UpperEndpoint()`: Gets the ending value of the interval. Throws an exception if there's no upper bound.
+*   `IsEmpty()`: Checks if the interval represents an empty range. An interval is empty if its definition results in no values being included (e.g., `[5..5)` which means "values greater than or equal to 5 AND less than 5", or `(5..5]` which means "values greater than 5 AND less than or equal to 5").
 
 ```cs
 Interval.ClosedOpen(4, 4).IsEmpty(); // returns true
@@ -122,30 +122,23 @@ Interval.Open(3, 10).UpperBoundType(); // returns Open
 
 #### `Encloses`
 
-The most basic relation on intervals is `Encloses(Interval)`, which is true if the
-bounds of the inner interval do not extend outside the bounds of the outer interval.
-This is solely dependent on comparisons between the endpoints!
+`Encloses(Interval otherInterval)` checks if this interval completely contains another interval. This means the `otherInterval`'s start and end points don't go beyond this one's start and end points. The type of bounds (open/closed) also matters.
 
-*   `[3..6]` encloses `[4..5]`
-*   `(3..6)` encloses `(3..6)`
-*   `[3..6]` encloses `[4..4)` (even though the latter is empty)
-*   `(3..6]` does not enclose `[3..6]`
-*   `[4..5]` does not enclose `(3..6)` **even though it contains every value
-    contained by the latter interval**
-*   `[3..6]` does not enclose `(1..1]` **even though it contains every value
-    contained by the latter interval**
+*   `[3..6]` encloses `[4..5]` (True: 4 is after 3, 5 is before 6, and the bounds are compatible)
+*   `(3..6)` encloses `(3..6)` (True: Identical intervals)
+*   `[3..6]` encloses `[4..4)` (True: Even though `[4..4)` is empty, its conceptual bounds fit within `[3..6]`)
+*   `(3..6)` does not enclose `[3..6]` (False: The outer interval `(3..6)` excludes 3 and 6, while the inner `[3..6]` includes them. So, the inner interval is not *entirely* within the outer one's boundary rules.)
+*   `[4..5]` does not enclose `(3..6)` (False: The interval `(3..6)` starts before 4 and ends after 5).
+    *   **Important Note:** `Encloses` is about whether the *boundaries* of one interval fit within another, including how endpoints are treated (open/closed). It's possible for all *values* of one interval to be contained in another, but for the second interval not to be *enclosed*. For example, `[4..5]` contains every value present in `(4..4.5)` (e.g., 4.2). However, if we consider `(3..6)`, its bounds 3 and 6 are outside of `[4..5]`, so `[4..5]` does not enclose `(3..6)`.
+*   `[3..6]` does not enclose `(1..1]` (False: `(1..1]` is empty, but its conceptual lower bound 1 is outside `[3..6]`).
 
 Given this, `Interval` provides the following operations:
 
 #### `IsConnected`
 
-`Interval.IsConnected(Interval)`, which tests if these intervals are *connected*.
-Specifically, `isConnected` tests if there is some interval enclosed by both of
-these intervals, but this is equivalent to the mathematical definition that the
-union of the intervals must form a connected set (except in the special case of
-empty intervals).
+`IsConnected(Interval otherInterval)` checks if two intervals touch or overlap, meaning there's no gap between them. If they are connected, their combined span forms a new, single continuous interval.
 
-`IsConnected` is a reflexive, symmetric relation.
+`IsConnected` is a reflexive (an interval is connected to itself) and symmetric (if A is connected to B, B is connected to A) relation.
 
 ```cs
 Interval.Closed(3, 5).IsConnected(Interval.Open(5, 10)); // returns true
@@ -157,11 +150,9 @@ Interval.Closed(1, 5).IsConnected(Interval.Closed(6, 10)); // returns false
 
 #### `Intersection`
 
-`Interval.Intersection(Interval)` returns the maximal interval enclosed by both this
-interval and other (which exists iff these intervals are connected), or if no such
-interval exists, throws an `ArgumentException`.
+`Intersection(Interval otherInterval)` finds the common part of two intervals—that is, the range of values that exists in *both* intervals. If the intervals don't overlap (i.e., they are not connected), this operation is not possible and will throw an `ArgumentException`.
 
-`Intersection` is a commutative, associative operation.
+`Intersection` is a commutative (A intersect B = B intersect A) and associative ( (A intersect B) intersect C = A intersect (B intersect C) ) operation.
 
 ```cs
 Interval.Closed(3, 5).Intersection(Interval.Open(5, 10)); // returns (5, 5]
@@ -173,10 +164,9 @@ Interval.Closed(1, 5).Intersection(Interval.Closed(6, 10)); // throws AE
 
 #### `Span`
 
-`Interval.Span(Interval)` returns the minimal interval that encloses both this interval
-and other. If the intervals are both connected, this is their union.
+`Span(Interval otherInterval)` returns the smallest single interval that covers *both* input intervals. If the intervals touch or overlap, their span is effectively their union. If there's a gap between them, the span will include that gap.
 
-`Span` is a commutative, associative and closed operation.
+`Span` is a commutative (A span B = B span A), associative ( (A span B) span C = A span (B span C) ), and closed (the result is always a valid interval) operation.
 
 ```cs
 Interval.Closed(3, 5).Span(Interval.Open(5, 10)); // returns [3, 10)

--- a/README.md
+++ b/README.md
@@ -15,18 +15,20 @@ Intervals can be finite (e.g., numbers between 2 and 5) or they can extend indef
 
 To describe intervals concisely, we use a common mathematical notation:
 
-*   An interval like **`(a..b)`** represents all values **greater than 'a' and less than 'b'**. 'a' and 'b' themselves are *not* included. This is called an **open interval**. For example, `(1..5)` includes numbers like 1.1, 2, 4.9, but not 1 or 5.
-*   An interval like **`[a..b]`** represents all values **greater than or equal to 'a' and less than or equal to 'b'**. 'a' and 'b' *are* included. This is called a **closed interval**. For example, `[1..5]` includes 1, 5, and all numbers in between.
-*   An interval like **`[a..b)`** represents all values **greater than or equal to 'a' and less than 'b'**. 'a' *is* included, but 'b' is *not*. This is a **half-open interval** (closed at the start, open at the end). For example, `[1..5)` includes 1, 4.999..., but not 5.
-*   An interval like **`(a..b]`** represents all values **greater than 'a' and less than or equal to 'b'**. 'a' is *not* included, but 'b' *is*. This is also a **half-open interval** (open at the start, closed at the end). For example, `(1..5]` includes 1.000...1, 5, but not 1.
+*   An interval like **`(a..b)`** represents all values **greater than 'a' and less than 'b'**. 'a' and 'b' themselves are *not* included. This is called an **open interval**. For example, if we are considering integers, `(1..5)` includes 2, 3, and 4, but not 1 or 5.
+*   An interval like **`[a..b]`** represents all values **greater than or equal to 'a' and less than or equal to 'b'**. 'a' and 'b' *are* included. This is called a **closed interval**. For example, if we are considering integers, `[1..5]` includes 1, 2, 3, 4, and 5.
+*   An interval like **`[a..b)`** represents all values **greater than or equal to 'a' and less than 'b'**. 'a' *is* included, but 'b' is *not*. This is a **half-open interval** (closed at the start, open at the end). For example, if we are considering integers, `[1..5)` includes 1, 2, 3, and 4, but not 5.
+*   An interval like **`(a..b]`** represents all values **greater than 'a' and less than or equal to 'b'**. 'a' is *not* included, but 'b' *is*. This is also a **half-open interval** (open at the start, closed at the end). For example, if we are considering integers, `(1..5]` includes 2, 3, 4, and 5, but not 1.
 
 Intervals can also be unbounded on one side, using `+∞` (positive infinity) or `-∞` (negative infinity):
 
-*   **`(a..+∞)`**: All values **strictly greater than 'a'**. For example, `(5..+∞)` means all numbers from 5.000...1 upwards.
-*   **`[a..+∞)`**: All values **greater than or equal to 'a'**. For example, `[5..+∞)` means all numbers from 5 upwards.
-*   **`(-∞..b)`**: All values **strictly less than 'b'**. For example, `(-∞..5)` means all numbers up to 4.999....
-*   **`(-∞..b]`**: All values **less than or equal to 'b'**. For example, `(-∞..5]` means all numbers up to 5.
+*   **`(a..+∞)`**: All values **strictly greater than 'a'**. For example, `(5..+∞)` means all values strictly greater than 5. If considering integers, this would be 6, 7, 8, and so on.
+*   **`[a..+∞)`**: All values **greater than or equal to 'a'**. For example, `[5..+∞)` means all values greater than or equal to 5. If considering integers, this would be 5, 6, 7, and so on.
+*   **`(-∞..b)`**: All values **strictly less than 'b'**. For example, `(-∞..5)` means all values strictly less than 5. If considering integers, this would be 4, 3, 2, and so on.
+*   **`(-∞..b]`**: All values **less than or equal to 'b'**. For example, `(-∞..5)` means all values less than or equal to 5. If considering integers, this would be 5, 4, 3, and so on.
 *   **`(-∞..+∞)`**: Represents **all possible values** in the domain.
+
+These examples often use integers for simplicity, but `Interval<T>` can work with any comparable type, such as `double`, `decimal`, `DateTime`, or `string` (where comparisons are typically alphabetical).
 
 The values 'a' and 'b' in these notations are called the **endpoints** of the interval. They define the boundaries of the range.
 Whether an endpoint is included or excluded determines if the interval's bound is **closed** (inclusive) or **open** (exclusive).

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Interval.Open(3, 10).UpperBoundType(); // returns Open
 
 #### `Encloses`
 
-`Encloses(Interval otherInterval)` checks if this interval completely contains another interval. This means the `otherInterval`'s start and end points don't go beyond this one's start and end points. The type of bounds (open/closed) also matters.
+An interval can check if it `Encloses(otherInterval)`, which is true if the `otherInterval`'s start and end points don't go beyond this one's start and end points. The type of bounds (open/closed) also matters.
 
 *   `[3..6]` encloses `[4..5]` (True: 4 is after 3, 5 is before 6, and the bounds are compatible)
 *   `(3..6)` encloses `(3..6)` (True: Identical intervals)
@@ -136,7 +136,7 @@ Given this, `Interval` provides the following operations:
 
 #### `IsConnected`
 
-`IsConnected(Interval otherInterval)` checks if two intervals touch or overlap, meaning there's no gap between them. If they are connected, their combined span forms a new, single continuous interval.
+An interval can test if it `IsConnected(otherInterval)`. This checks if two intervals touch or overlap, meaning there's no gap between them. If they are connected, their combined span forms a new, single continuous interval.
 
 `IsConnected` is a reflexive (an interval is connected to itself) and symmetric (if A is connected to B, B is connected to A) relation.
 
@@ -150,30 +150,54 @@ Interval.Closed(1, 5).IsConnected(Interval.Closed(6, 10)); // returns false
 
 #### `Intersection`
 
-`Intersection(Interval otherInterval)` finds the common part of two intervals—that is, the range of values that exists in *both* intervals. If the intervals don't overlap (i.e., they are not connected), this operation is not possible and will throw an `ArgumentException`.
+An interval can find its `Intersection(otherInterval)`, which returns the maximal interval representing the common part of two intervals—that is, the range of values that exists in *both* intervals. If the intervals don't overlap (i.e., they are not connected), this operation is not possible and will throw an `ArgumentException`.
 
 `Intersection` is a commutative (A intersect B = B intersect A) and associative ( (A intersect B) intersect C = A intersect (B intersect C) ) operation.
 
 ```cs
-Interval.Closed(3, 5).Intersection(Interval.Open(5, 10)); // returns (5, 5]
-Interval.Closed(0, 9).Intersection(Interval.Closed(3, 4)); // returns [3, 4]
-Interval.Closed(0, 5).Intersection(Interval.Closed(3, 9)); // returns [3, 5]
-Interval.Open(3, 5).Intersection(Interval.Open(5, 10)); // throws AE
-Interval.Closed(1, 5).Intersection(Interval.Closed(6, 10)); // throws AE
+var intervalA = Interval.Closed(3, 5);
+var intervalB = Interval.Open(5, 10);
+var intersection1 = intervalA.Intersection(intervalB); // returns (5, 5]
+
+var intervalC = Interval.Closed(0, 9);
+var intervalD = Interval.Closed(3, 4);
+var intersection2 = intervalC.Intersection(intervalD); // returns [3, 4]
+
+var intervalE = Interval.Closed(0, 5);
+var intervalF = Interval.Closed(3, 9);
+var intersection3 = intervalE.Intersection(intervalF); // returns [3, 5]
+
+// Examples that throw ArgumentException because intervals are not connected:
+// Interval.Open(3, 5).Intersection(Interval.Open(5, 10));
+// Interval.Closed(1, 5).Intersection(Interval.Closed(6, 10));
 ```
 
 #### `Span`
 
-`Span(Interval otherInterval)` returns the smallest single interval that covers *both* input intervals. If the intervals touch or overlap, their span is effectively their union. If there's a gap between them, the span will include that gap.
+An interval can determine its `Span(otherInterval)`, which returns the minimal interval that covers *both* input intervals. If the intervals touch or overlap, their span is effectively their union. If there's a gap between them, the span will include that gap.
 
 `Span` is a commutative (A span B = B span A), associative ( (A span B) span C = A span (B span C) ), and closed (the result is always a valid interval) operation.
 
 ```cs
-Interval.Closed(3, 5).Span(Interval.Open(5, 10)); // returns [3, 10)
-Interval.Closed(0, 9).Span(Interval.Closed(3, 4)); // returns [0, 9]
-Interval.Closed(0, 5).Span(Interval.Closed(3, 9)); // returns [0, 9]
-Interval.Open(3, 5).Span(Interval.Open(5, 10)); // returns (3, 10)
-Interval.Closed(1, 5).Span(Interval.Closed(6, 10)); // returns [1, 10]
+var intervalA = Interval.Closed(3, 5);
+var intervalB = Interval.Open(5, 10);
+var span1 = intervalA.Span(intervalB); // returns [3, 10)
+
+var intervalC = Interval.Closed(0, 9);
+var intervalD = Interval.Closed(3, 4);
+var span2 = intervalC.Span(intervalD); // returns [0, 9]
+
+var intervalE = Interval.Closed(0, 5);
+var intervalF = Interval.Closed(3, 9);
+var span3 = intervalE.Span(intervalF); // returns [0, 9]
+
+var intervalG = Interval.Open(3, 5);
+var intervalH = Interval.Open(5, 10);
+var span4 = intervalG.Span(intervalH); // returns (3, 10)
+
+var intervalI = Interval.Closed(1, 5);
+var intervalJ = Interval.Closed(6, 10);
+var span5 = intervalI.Span(intervalJ); // returns [1, 10]
 ```
 
 ## Credits

--- a/src/SharpInterval.Tests/IntervalTest.cs
+++ b/src/SharpInterval.Tests/IntervalTest.cs
@@ -534,10 +534,9 @@ public class IntervalTest
         Interval.Closed(3, 6).Encloses(Interval.Closed(4, 5)).Should().BeTrue();
         Interval.Open(3, 6).Encloses(Interval.Open(3, 6)).Should().BeTrue();
         Interval.Closed(4, 5).Encloses(Interval.Open(3, 6)).Should().BeFalse();
-        // Additional Encloses assertions
-        Interval.Closed(3, 6).Encloses(Interval.ClosedOpen(4, 4)).Should().BeTrue(); // for "[3..6] encloses [4..4)"
-        Interval.Open(3, 6).Encloses(Interval.Closed(3, 6)).Should().BeFalse(); // for "(3..6) does not enclose [3..6]"
-        Interval.Closed(3, 6).Encloses(Interval.OpenClosed(1, 1)).Should().BeFalse(); // for "[3..6] does not enclose (1..1]"
+        Interval.Closed(3, 6).Encloses(Interval.ClosedOpen(4, 4)).Should().BeTrue();
+        Interval.Open(3, 6).Encloses(Interval.Closed(3, 6)).Should().BeFalse();
+        Interval.Closed(3, 6).Encloses(Interval.OpenClosed(1, 1)).Should().BeFalse();
 
         Interval.Closed(3, 5).IsConnected(Interval.Open(5, 10)).Should().BeTrue();
         Interval.Closed(0, 9).IsConnected(Interval.Closed(3, 4)).Should().BeTrue();

--- a/src/SharpInterval.Tests/IntervalTest.cs
+++ b/src/SharpInterval.Tests/IntervalTest.cs
@@ -503,16 +503,12 @@ public class IntervalTest
         lexiInterval.Contains("lift").Should().BeTrue();
         Interval.LessThan(4.0);
 
-        // Test for Interval.DownTo with BoundType.Closed
-        var closedBoundType = BoundType.Closed;
-        var downToClosed = Interval.DownTo(4, closedBoundType);
+        var downToClosed = Interval.DownTo(4, BoundType.Closed);
         downToClosed.Should().Be(Interval.AtLeast(4)); // Verify it's equivalent
         downToClosed.Contains(4).Should().BeTrue();
         downToClosed.Contains(3).Should().BeFalse();
 
-        // Test for Interval.DownTo with BoundType.Open
-        var openBoundType = BoundType.Open;
-        var downToOpen = Interval.DownTo(4, openBoundType);
+        var downToOpen = Interval.DownTo(4, BoundType.Open);
         downToOpen.Should().Be(Interval.GreaterThan(4)); // Verify it's equivalent
         downToOpen.Contains(4).Should().BeFalse();
         downToOpen.Contains(5).Should().BeTrue();

--- a/src/SharpInterval.Tests/IntervalTest.cs
+++ b/src/SharpInterval.Tests/IntervalTest.cs
@@ -503,8 +503,20 @@ public class IntervalTest
         lexiInterval.Contains("lift").Should().BeTrue();
         Interval.LessThan(4.0);
 
-        var boundType = BoundType.Closed;
-        Interval.DownTo(4, boundType);
+        // Test for Interval.DownTo with BoundType.Closed
+        var closedBoundType = BoundType.Closed;
+        var downToClosed = Interval.DownTo(4, closedBoundType);
+        downToClosed.Should().Be(Interval.AtLeast(4)); // Verify it's equivalent
+        downToClosed.Contains(4).Should().BeTrue();
+        downToClosed.Contains(3).Should().BeFalse();
+
+        // Test for Interval.DownTo with BoundType.Open
+        var openBoundType = BoundType.Open;
+        var downToOpen = Interval.DownTo(4, openBoundType);
+        downToOpen.Should().Be(Interval.GreaterThan(4)); // Verify it's equivalent
+        downToOpen.Contains(4).Should().BeFalse();
+        downToOpen.Contains(5).Should().BeTrue();
+
         Interval.Bounded(1, BoundType.Closed, 4, BoundType.Open);
 
         Interval.Closed(1, 3).Contains(2).Should().BeTrue();
@@ -526,6 +538,10 @@ public class IntervalTest
         Interval.Closed(3, 6).Encloses(Interval.Closed(4, 5)).Should().BeTrue();
         Interval.Open(3, 6).Encloses(Interval.Open(3, 6)).Should().BeTrue();
         Interval.Closed(4, 5).Encloses(Interval.Open(3, 6)).Should().BeFalse();
+        // Additional Encloses assertions
+        Interval.Closed(3, 6).Encloses(Interval.ClosedOpen(4, 4)).Should().BeTrue(); // for "[3..6] encloses [4..4)"
+        Interval.Open(3, 6).Encloses(Interval.Closed(3, 6)).Should().BeFalse(); // for "(3..6) does not enclose [3..6]"
+        Interval.Closed(3, 6).Encloses(Interval.OpenClosed(1, 1)).Should().BeFalse(); // for "[3..6] does not enclose (1..1]"
 
         Interval.Closed(3, 5).IsConnected(Interval.Open(5, 10)).Should().BeTrue();
         Interval.Closed(0, 9).IsConnected(Interval.Closed(3, 4)).Should().BeTrue();

--- a/src/SharpInterval.Tests/IntervalTest.cs
+++ b/src/SharpInterval.Tests/IntervalTest.cs
@@ -504,12 +504,12 @@ public class IntervalTest
         Interval.LessThan(4.0);
 
         var downToClosed = Interval.DownTo(4, BoundType.Closed);
-        downToClosed.Should().Be(Interval.AtLeast(4)); // Verify it's equivalent
+        downToClosed.Should().Be(Interval.AtLeast(4));
         downToClosed.Contains(4).Should().BeTrue();
         downToClosed.Contains(3).Should().BeFalse();
 
         var downToOpen = Interval.DownTo(4, BoundType.Open);
-        downToOpen.Should().Be(Interval.GreaterThan(4)); // Verify it's equivalent
+        downToOpen.Should().Be(Interval.GreaterThan(4));
         downToOpen.Contains(4).Should().BeFalse();
         downToOpen.Contains(5).Should().BeTrue();
 

--- a/src/SharpInterval/BoundType.cs
+++ b/src/SharpInterval/BoundType.cs
@@ -3,9 +3,9 @@
 namespace SharpInterval;
 
 /// <summary>
-/// Indicates whether an endpoint of some interval is contained in the interval itself ("closed") or not
-/// ("open"). If an interval is unbounded on a side, it is neither open nor closed on that side; the
-/// bound simply does not exist.
+/// Specifies whether an interval's endpoint is included in the interval ('Closed') or excluded ('Open').
+/// For intervals that are unbounded on a side (extending to infinity), that side doesn't have a
+/// conventional open or closed bound.
 /// </summary>
 [Serializable]
 public enum BoundType

--- a/src/SharpInterval/Cut.cs
+++ b/src/SharpInterval/Cut.cs
@@ -28,11 +28,9 @@ internal class Cut
 }
 
 /// <summary>
-/// Implementation detail for the internal structure of <seealso cref="Interval{T}"/> instances. Represents a unique
-/// way of "cutting" a "number line" (actually of instances of type <typeparamref name="T"/>, not necessarily
-/// "numbers") into two sections; this can be done below a certain value, above a certain value,
-/// below all values or above all values. With this object defined in this way, an interval can
-/// always be represented by a pair of <seealso cref="Cut{T}"/> instances.
+/// Internal helper class for <seealso cref="Interval{T}"/>. It defines a specific point (or 'cut')
+/// on a sequence of values. An interval is essentially defined by two such cuts: one for its start
+/// and one for its end.
 /// </summary>
 [Serializable]
 internal abstract class Cut<T> : IComparable<Cut<T>> where T : IComparable<T>

--- a/src/SharpInterval/Interval.cs
+++ b/src/SharpInterval/Interval.cs
@@ -14,8 +14,8 @@ namespace SharpInterval;
 public static class Interval
 {
     /// <summary>
-    /// Returns an interval that contains all values strictly greater than <paramref name="lower"/> and strictly less
-    /// than <paramref name="upper"/>.
+    /// Creates an interval representing all values that are strictly greater than <paramref name="lower"/> and strictly less
+    /// than <paramref name="upper"/>. Neither <paramref name="lower"/> nor <paramref name="upper"/> are included in the interval.
     /// </summary>
     /// <exception cref="ArgumentException"> if <paramref name="lower"/> is greater than or equal to <paramref name="upper"/>
     /// </exception>
@@ -25,8 +25,8 @@ public static class Interval
     }
 
     /// <summary>
-    /// Returns an interval that contains all values greater than or equal to <paramref name="lower"/> and less than
-    /// or equal to <paramref name="upper"/>.
+    /// Creates an interval representing all values from <paramref name="lower"/> to <paramref name="upper"/>,
+    /// including both <paramref name="lower"/> and <paramref name="upper"/>.
     /// </summary>
     /// <exception cref="ArgumentException"> if <paramref name="lower"/> is greater than <paramref name="upper"/>
     /// </exception>
@@ -36,8 +36,8 @@ public static class Interval
     }
 
     /// <summary>
-    /// Returns an interval that contains all values greater than or equal to <paramref name="lower"/> and strictly
-    /// less than <paramref name="upper"/>.
+    /// Creates an interval representing all values from <paramref name="lower"/> (inclusive) up to, but not including,
+    /// <paramref name="upper"/> (exclusive).
     /// </summary>
     /// <exception cref="ArgumentException"> if <paramref name="lower"/> is greater than <paramref name="upper"/>
     /// </exception>
@@ -47,8 +47,8 @@ public static class Interval
     }
 
     /// <summary>
-    /// Returns an interval that contains all values strictly greater than <paramref name="lower"/> and less than or
-    /// equal to <paramref name="upper"/>.
+    /// Creates an interval representing all values strictly greater than <paramref name="lower"/> (exclusive) up to,
+    /// and including, <paramref name="upper"/> (inclusive).
     /// </summary>
     /// <exception cref="ArgumentException"> if <paramref name="lower"/> is greater than <paramref name="upper"/>
     /// </exception>
@@ -58,8 +58,9 @@ public static class Interval
     }
 
     /// <summary>
-    /// Returns an interval that contains any value from <paramref name="lower"/> to <paramref name="upper"/>, where each
-    /// endpoint may be either inclusive (closed) or exclusive (open).
+    /// Creates an interval from <paramref name="lower"/> to <paramref name="upper"/>. You can specify whether
+    /// <paramref name="lower"/> and <paramref name="upper"/> are included or excluded using <paramref name="lowerType"/>
+    /// and <paramref name="upperType"/> respectively.
     /// </summary>
     /// <exception cref="ArgumentException"> if <paramref name="lower"/> is greater than <paramref name="upper"/>
     /// </exception>
@@ -71,7 +72,8 @@ public static class Interval
     }
 
     /// <summary>
-    /// Returns an interval that contains all values strictly less than <paramref name="endpoint"/>.
+    /// Creates an interval representing all values strictly less than the <paramref name="endpoint"/>.
+    /// The <paramref name="endpoint"/> itself is not included. The interval has no lower bound (extends to negative infinity).
     /// </summary>
     public static Interval<T> LessThan<T>(T endpoint) where T : IComparable<T>
     {
@@ -79,7 +81,8 @@ public static class Interval
     }
 
     /// <summary>
-    /// Returns an interval that contains all values less than or equal to <paramref name="endpoint"/>.
+    /// Creates an interval representing all values less than or equal to the <paramref name="endpoint"/>.
+    /// The <paramref name="endpoint"/> itself is included. The interval has no lower bound (extends to negative infinity).
     /// </summary>
     public static Interval<T> AtMost<T>(T endpoint) where T : IComparable<T>
     {
@@ -87,8 +90,8 @@ public static class Interval
     }
 
     /// <summary>
-    /// Returns an interval with no lower bound up to the given endpoint, which may be either inclusive
-    /// (closed) or exclusive (open).
+    /// Creates an interval that extends indefinitely from negative infinity up to the specified <paramref name="endpoint"/>.
+    /// Whether the <paramref name="endpoint"/> is included or excluded is determined by <paramref name="boundType"/>.
     /// </summary>
     public static Interval<T> UpTo<T>(T endpoint, BoundType boundType) where T : IComparable<T>
     {
@@ -104,7 +107,8 @@ public static class Interval
     }
 
     /// <summary>
-    /// Returns an interval that contains all values strictly greater than <paramref name="endpoint"/>.
+    /// Creates an interval representing all values strictly greater than the <paramref name="endpoint"/>.
+    /// The <paramref name="endpoint"/> itself is not included. The interval has no upper bound (extends to positive infinity).
     /// </summary>
     public static Interval<T> GreaterThan<T>(T endpoint) where T : IComparable<T>
     {
@@ -112,7 +116,8 @@ public static class Interval
     }
 
     /// <summary>
-    /// Returns an interval that contains all values greater than or equal to <paramref name="endpoint"/>.
+    /// Creates an interval representing all values greater than or equal to the <paramref name="endpoint"/>.
+    /// The <paramref name="endpoint"/> itself is included. The interval has no upper bound (extends to positive infinity).
     /// </summary>
     public static Interval<T> AtLeast<T>(T endpoint) where T : IComparable<T>
     {
@@ -120,8 +125,8 @@ public static class Interval
     }
 
     /// <summary>
-    /// Returns an interval from the given endpoint, which may be either inclusive (closed) or exclusive
-    /// (open), with no upper bound.
+    /// Creates an interval that starts from the specified <paramref name="endpoint"/> and extends indefinitely to positive infinity.
+    /// Whether the <paramref name="endpoint"/> is included or excluded is determined by <paramref name="boundType"/>.
     /// </summary>
     public static Interval<T> DownTo<T>(T endpoint, BoundType boundType) where T : IComparable<T>
     {
@@ -137,7 +142,8 @@ public static class Interval
     }
 
     /// <summary>
-    /// Returns an interval that contains every value of type <typeparamref name="T"/>.
+    /// Creates an interval that represents all possible values of type <typeparamref name="T"/>.
+    /// It has no lower or upper bounds (extends from negative to positive infinity).
     /// </summary>
     public static Interval<T> All<T>() where T : IComparable<T>
     {
@@ -145,8 +151,8 @@ public static class Interval
     }
 
     /// <summary>
-    /// Returns an interval that contains only the given value. The
-    /// returned interval is closed on both ends.
+    /// Creates an interval that contains only a single <paramref name="value"/>.
+    /// This is equivalent to an interval where the start and end points are both <paramref name="value"/>, and both are included.
     /// </summary>
     public static Interval<T> Singleton<T>(T value) where T : IComparable<T>
     {
@@ -155,19 +161,19 @@ public static class Interval
 }
 
 /// <summary>
-/// An interval (sometimes called a range) defines the boundaries around a contiguous span of values of some
-/// <c>Comparable</c> type; for example, "integers from 1 to 100 inclusive." Note that it is not
-/// possible to iterate over these contained values.
+/// Represents an interval, which is a continuous range of values of a comparable type (e.g., numbers from 1 to 100).
+/// This class defines the boundaries of such a range but doesn't allow iterating through the individual values within it.
 /// </summary>
 /// <remarks>
-/// <para>An interval is a contiguous range of comparable values. Each side can be
-/// open, closed or unbounded, and factory methods exist for the common forms.</para>
-/// <para>The upper endpoint may not be less than the lower one. They can coincide
-/// only if at least one side is closed.</para>
+/// <para>An interval represents a continuous set of values. Its start and end points can be 'open' (value excluded),
+/// 'closed' (value included), or 'unbounded' (extending to infinity). Helper methods are available to create
+/// common types of intervals easily.</para>
+/// <para>The end point of an interval cannot be before its start point. The start and end points can be the same value
+/// if the interval includes that value (i.e., at least one bound is 'closed').</para>
 /// <para>Use immutable value types whenever possible and ensure comparisons are
 /// consistent with equality.</para>
-/// <para>Intervals are convex: whenever two values are contained, all values in
-/// between them are contained as well.</para>
+/// <para>A key property of intervals is that they are 'convex', meaning if two values are in the interval,
+/// all values between them are also in the interval.</para>
 /// </remarks>
 [Serializable]
 public sealed class Interval<T> where T : IComparable<T>
@@ -187,7 +193,7 @@ public sealed class Interval<T> where T : IComparable<T>
     }
 
     /// <summary>
-    /// Returns <c>true</c> if this interval has a lower endpoint.
+    /// Checks if this interval has a defined starting point (it's not unbounded towards negative infinity).
     /// </summary>
     public bool HasLowerBound()
     {
@@ -195,9 +201,9 @@ public sealed class Interval<T> where T : IComparable<T>
     }
 
     /// <summary>
-    /// Returns the lower endpoint of this interval.
+    /// Gets the starting value of this interval.
     /// </summary>
-    /// <exception cref="InvalidOperationException"> if this interval is unbounded below
+    /// <exception cref="InvalidOperationException"> if this interval has no defined starting point (i.e., it extends to negative infinity)
     /// (that is, <seealso cref="Interval{T}.HasLowerBound"/> returns <c>false</c>)</exception>
     public T LowerEndpoint()
     {
@@ -205,10 +211,9 @@ public sealed class Interval<T> where T : IComparable<T>
     }
 
     /// <summary>
-    /// Returns the type of this interval's lower bound: <seealso cref="BoundType.Closed"/> if the interval includes
-    /// its lower endpoint, <seealso cref="BoundType.Open"/> if it does not.
+    /// Determines if the interval's starting point is 'Open' (start value not included) or 'Closed' (start value included).
     /// </summary>
-    /// <exception cref="InvalidOperationException"> if this interval is unbounded below
+    /// <exception cref="InvalidOperationException"> if this interval has no defined starting point
     /// (that is, <seealso cref="Interval{T}.HasLowerBound"/> returns <c>false</c>)</exception>
     public BoundType LowerBoundType()
     {
@@ -216,16 +221,17 @@ public sealed class Interval<T> where T : IComparable<T>
     }
 
     /// <summary>
-    /// Returns <c>true</c> if this interval has an upper endpoint. </summary>
+    /// Checks if this interval has a defined ending point (it's not unbounded towards positive infinity).
+    /// </summary>
     public bool HasUpperBound()
     {
         return _upperBound != Cut.AboveAll<T>();
     }
 
     /// <summary>
-    /// Returns the upper endpoint of this interval.
+    /// Gets the ending value of this interval.
     /// </summary>
-    /// <exception cref="InvalidOperationException"> if this interval is unbounded above
+    /// <exception cref="InvalidOperationException"> if this interval has no defined ending point (i.e., it extends to positive infinity)
     /// (that is, <seealso cref="Interval{T}.HasUpperBound"/> returns <c>false</c>)</exception>
     public T UpperEndpoint()
     {
@@ -233,10 +239,9 @@ public sealed class Interval<T> where T : IComparable<T>
     }
 
     /// <summary>
-    /// Returns the type of this interval's upper bound: <seealso cref="BoundType.Closed"/> if the interval includes
-    /// its upper endpoint, <seealso cref="BoundType.Open"/> if it does not.
+    /// Determines if the interval's ending point is 'Open' (end value not included) or 'Closed' (end value included).
     /// </summary>
-    /// <exception cref="InvalidOperationException"> if this interval is unbounded above
+    /// <exception cref="InvalidOperationException"> if this interval has no defined ending point
     /// (that is, <seealso cref="Interval{T}.HasUpperBound"/> returns <c>false</c>)</exception>
     public BoundType UpperBoundType()
     {
@@ -244,8 +249,8 @@ public sealed class Interval<T> where T : IComparable<T>
     }
 
     /// <summary>
-    /// Returns <c>true</c> if this interval is of the form <c>[v..v)</c> or <c>(v..v]</c>. (This does
-    /// not encompass intervals of the form <c>(v..v)</c>, because such intervals are invalid and
+    /// Checks if the interval contains no values. For example, an interval like `[5..5)` (from 5, including 5, up to 5, excluding 5) is empty.
+    /// (This does not encompass intervals of the form <c>(v..v)</c>, because such intervals are invalid and
     /// can't be constructed at all.)
     /// 
     /// <para>Note that certain discrete intervals such as the integer interval <c>(3..4)</c> are not
@@ -258,7 +263,7 @@ public sealed class Interval<T> where T : IComparable<T>
     }
 
     /// <summary>
-    /// Returns <c>true</c> if <c>value</c> is within the bounds of this interval. For example, on the
+    /// Checks if the given <paramref name="value"/> is within this interval. For example, on the
     /// interval <c>[0..2)</c>, <c>contains(1)</c> returns <c>true</c>, while <c>contains(2)</c>
     /// returns <c>false</c>.
     /// </summary>
@@ -269,7 +274,7 @@ public sealed class Interval<T> where T : IComparable<T>
     }
 
     /// <summary>
-    /// Returns <c>true</c> if every element in <c>values</c> is contained in this interval.
+    /// Checks if every element in the provided <paramref name="values"/> collection is contained in this interval.
     /// </summary>
     public bool ContainsAll<T1>(IEnumerable<T1> values) where T1 : T
     {
@@ -284,21 +289,19 @@ public sealed class Interval<T> where T : IComparable<T>
     }
 
     /// <summary>
-    /// Returns <c>true</c> if the bounds of <c>other</c> do not extend outside the bounds of this
-    /// interval. Examples:
-    /// 
+    /// Checks if this interval completely contains the <paramref name="other"/> interval.
+    /// This means the <paramref name="other"/> interval's start and end points must not extend beyond this interval's own start and end points.
+    /// Examples:
     /// <list type="bullet">
-    /// <item><description><c>[3..6]</c> encloses <c>[4..5]</c></description></item>
-    /// <item><description><c>(3..6)</c> encloses <c>(3..6)</c></description></item>
-    /// <item><description><c>[3..6]</c> encloses <c>[4..4)</c> (even though the latter is empty)</description></item>
-    /// <item><description><c>(3..6]</c> does not enclose <c>[3..6]</c></description></item>
-    /// <item><description><c>[4..5]</c> does not enclose <c>(3..6)</c> (even though it contains every value
-    /// contained by the latter interval)</description></item>
-    /// <item><description><c>[3..6]</c> does not enclose <c>(1..1]</c> (even though it contains every value
-    /// contained by the latter interval)</description></item>
+    /// <item><description><c>[3..6]</c> encloses <c>[4..5]</c> (True)</description></item>
+    /// <item><description><c>(3..6)</c> encloses <c>(3..6)</c> (True)</description></item>
+    /// <item><description><c>[3..6]</c> encloses <c>[4..4)</c> (True, even though <c>[4..4)</c> is empty)</description></item>
+    /// <item><description><c>(3..6]</c> does not enclose <c>[3..6]</c> (False, because the start of <c>[3..6]</c> is '3 inclusive', which is not in <c>(3..6]</c>)</description></item>
+    /// <item><description><c>[4..5]</c> does not enclose <c>(3..6)</c> (False, because <c>(3..6)</c> extends beyond <c>[4..5]</c>)</description></item>
     /// </list>
     /// 
-    /// <para>Note that if <c>a.encloses(b)</c>, then <c>b.contains(v)</c> implies <c>a.contains(v)</c>, but as the last two examples illustrate, the converse is not always true.
+    /// <para>If <c>A.Encloses(B)</c> is true, then any value contained in B is also contained in A.
+    /// However, the reverse is not always true. For example, <c>[4..5]</c> contains all values of <c>(4.0..4.5)</c>, but <c>[4..5]</c> does not enclose <c>(3..6)</c>.
     /// 
     /// </para>
     /// <para>Being reflexive, antisymmetric and transitive, the <c>encloses</c> relation defines a
@@ -313,15 +316,13 @@ public sealed class Interval<T> where T : IComparable<T>
     }
 
     /// <summary>
-    /// Returns <c>true</c> if there exists a (possibly empty) interval that is enclosed by both this interval and <paramref name="other"/>.
+    /// Checks if this interval and the <paramref name="other"/> interval touch or overlap, meaning there is no gap between them.
     /// 
-    /// <para>For example,
-    /// 
+    /// <para>For example:
     /// <list type="bullet">
-    /// <item><description><c>[2, 4)</c> and <c>[5, 7)</c> are not connected</description></item>
-    /// <item><description><c>[2, 4)</c> and <c>[3, 5)</c> are connected, because both enclose <c>[3, 4)</c></description></item>
-    /// <item><description><c>[2, 4)</c> and <c>[4, 6)</c> are connected, because both enclose the empty interval
-    /// <c>[4, 4)</c></description></item>
+    /// <item><description><c>[2..4)</c> and <c>[5..7)</c> are not connected (gap between 4 and 5).</description></item>
+    /// <item><description><c>[2..4)</c> and <c>[3..5)</c> are connected (overlap is <c>[3..4)</c>).</description></item>
+    /// <item><description><c>[2..4)</c> and <c>[4..6)</c> are connected (touch at 4, the empty interval <c>[4..4)</c> is common).</description></item>
     /// </list>
     /// 
     /// </para>
@@ -346,21 +347,18 @@ public sealed class Interval<T> where T : IComparable<T>
     }
 
     /// <summary>
-    /// Returns the maximal interval enclosed by both this interval and <paramref name="connectedRange"/>, if such an interval exists.
+    /// Calculates the common part (overlap) of this interval and <paramref name="connectedRange"/>.
     /// 
-    /// <para>For example, the intersection of <c>[1..5]</c> and <c>(3..7)</c> is <c>(3..5]</c>. The
-    /// resulting interval may be empty; for example, <c>[1..5)</c> intersected with <c>[5..7)</c>
-    /// yields the empty interval <c>[5..5)</c>.
+    /// <para>For example, the intersection of <c>[1..5]</c> and <c>(3..7)</c> is <c>(3..5]</c>.
+    /// The result can be an empty interval, e.g., <c>[1..5)</c> intersected with <c>[5..7)</c> results in <c>[5..5)</c>.
     /// 
     /// </para>
-    /// <para>The intersection exists if and only if the two intervals are connected
-    /// (<see cref="IsConnected"/>).</para>
+    /// <para>This operation is only valid if the two intervals are connected (i.e., they touch or overlap, as determined by <see cref="IsConnected"/>).</para>
     /// <para>The intersection operation is commutative, associative and idempotent, and its identity
     /// element is <seealso cref="Interval.All{T}"/>).
-    /// 
     /// </para>
     /// </summary>
-    /// <exception cref="ArgumentException"> if <c>isConnected(connectedRange)</c> is <c>false</c> </exception>
+    /// <exception cref="ArgumentException"> if the intervals are not connected (<c>IsConnected(connectedRange)</c> is <c>false</c>). </exception>
     public Interval<T> Intersection(Interval<T> connectedRange)
     {
         int lowerCmp = _lowerBound.CompareTo(connectedRange._lowerBound);
@@ -382,12 +380,12 @@ public sealed class Interval<T> where T : IComparable<T>
     }
 
     /// <summary>
-    /// Returns the minimal interval that encloses both this interval and <paramref name="other"/>.
+    /// Calculates the smallest single interval that encompasses both this interval and the <paramref name="other"/> interval.
     /// For example, the span of <c>[1..3]</c> and <c>(5..7)</c> is <c>[1..7)</c>.
     /// 
-    /// <para>If the input intervals are connected, the returned interval can
-    /// also be called their union. If they are not, note that the span might contain values
-    /// that are not contained in either input interval.
+    /// <para>If the two input intervals are connected (touch or overlap), their span is effectively their union.
+    /// If they are not connected (there's a gap between them), the span will include that gap as well.
+    /// For instance, the span of <c>[1..3]</c> and <c>[5..7]</c> is <c>[1..7]</c>.
     /// 
     /// </para>
     /// <para>Like <seealso cref="Interval{T}.Intersection(Interval{T})"/>, this operation is commutative, associative
@@ -415,11 +413,10 @@ public sealed class Interval<T> where T : IComparable<T>
     }
 
     /// <summary>
-    /// Returns <c>true</c> if <c>object</c> is an interval having the same endpoints and bound types as
-    /// this interval. Note that discrete intervals such as <c>(1..4)</c> and <c>[2..3]</c> are not
-    /// equal to one another, despite the fact that they each contain precisely the same set of values.
-    /// Similarly, empty intervals are not equal unless they have exactly the same representation, so
-    /// <c>[3..3)</c>, <c>(3..3]</c>, <c>(4..4]</c> are all unequal.
+    /// Checks if this interval is identical to another interval, meaning they have the same start and end points and the same bound types (Open/Closed).
+    /// Note that intervals like <c>(1..4)</c> (integers 2, 3) and <c>[2..3]</c> (integers 2, 3) are not
+    /// considered equal by this method, because their boundary definitions differ, even if they happen to contain the same set of discrete values.
+    /// Similarly, empty intervals like <c>[3..3)</c> and <c>(3..3]</c> are not equal.
     /// </summary>
     public override bool Equals(object? other)
     {


### PR DESCRIPTION
Updated README.md and XMLDoc comments to make them more accessible to you without a strong mathematical background.

Key changes include:
- Rephrased complex definitions using simpler terms.
- Provided verbose explanations for mathematical notations before introducing them as shorthand.
- Added "Plain English" explanations for interval construction methods.
- Clarified the behavior of interval operations like Encloses, IsConnected, Intersection, and Span with simpler definitions and easier-to-understand examples.
- Ensured consistency in terminology and explanations across all documentation.

The goal of these changes is to lower the barrier to entry for new users of the library while maintaining technical precision.