### PR TITLE
Make interval bounds private

### DIFF
--- a/src/SharpInterval/Interval.cs
+++ b/src/SharpInterval/Interval.cs
@@ -172,8 +172,8 @@ public static class Interval
 [Serializable]
 public sealed class Interval<C> where C : IComparable<C>
 {
-    internal readonly Cut<C> _lowerBound;
-    internal readonly Cut<C> _upperBound;
+    private readonly Cut<C> _lowerBound;
+    private readonly Cut<C> _upperBound;
 
     internal Interval(Cut<C> lowerBound, Cut<C> upperBound)
     {


### PR DESCRIPTION
## Summary
- restrict access to the underlying bounds in `Interval<C>`

## Testing
- `dotnet test SharpInterval.sln`